### PR TITLE
Make images responsive

### DIFF
--- a/neuroscience/planet.neuroscience.html.erb
+++ b/neuroscience/planet.neuroscience.html.erb
@@ -104,6 +104,12 @@
     </footer>
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+    <script type="text/javascript">
+      $( document ).ready(function(){
+        $("img").addClass("img-responsive");
+        $("figure").addClass("img-responsive");
+      });
+    </script>
     <!-- Include all compiled plugins (below), or include individual files as needed -->
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
   </body>


### PR DESCRIPTION
Since we are loading dynamic content, img and figure tags were not responsive. Bringing over this code from the old templates fixes that.